### PR TITLE
Fixing Issue #10 "Data too long for column 'ca_cert' at row 1"

### DIFF
--- a/docker_challenges/__init__.py
+++ b/docker_challenges/__init__.py
@@ -55,9 +55,9 @@ class DockerConfig(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     hostname = db.Column("hostname", db.String(64), index=True)
     tls_enabled = db.Column("tls_enabled", db.Boolean, default=False, index=True)
-    ca_cert = db.Column("ca_cert", db.String(1024), index=True)
-    client_cert = db.Column("client_cert", db.String(1024), index=True)
-    client_key = db.Column("client_key", db.String(1024), index=True)
+    ca_cert = db.Column("ca_cert", db.String(2200), index=True)
+    client_cert = db.Column("client_cert", db.String(2000), index=True)
+    client_key = db.Column("client_key", db.String(3300), index=True)
     repositories = db.Column("repositories", db.String(1024), index=True)
 
 


### PR DESCRIPTION
Issue #10. Database gives an error when enabling TLS for the size of the `ca.pem`, `client-cert.pem` and `client-key.pem` files. This issue can be solved by making the 3 fields where the keys and certificates are stored bigger.