### PR TITLE
fix challenge deletion

### DIFF
--- a/docker_challenges/__init__.py
+++ b/docker_challenges/__init__.py
@@ -403,9 +403,9 @@ class DockerChallengeType(BaseChallenge):
             delete_file(f.id)
         ChallengeFiles.query.filter_by(challenge_id=challenge.id).delete()
         Tags.query.filter_by(challenge_id=challenge.id).delete()
-        Hints.query.filter_by(challenge_id=challenge.id).delete()
-        Challenges.query.filter_by(id=challenge.id).delete()
+        Hints.query.filter_by(challenge_id=challenge.id).delete()        
         DockerChallenge.query.filter_by(id=challenge.id).delete()
+	Challenges.query.filter_by(id=challenge.id).delete()
         db.session.commit()
 
     @staticmethod


### PR DESCRIPTION
docker challenges references the challenge id as foreign key in the CTFd Database. 
So deleting the the challenge before deleting the docker challenge throws an error. 
Switching the two statements to fix