### PR TITLE
Modify get_unavailable_ports to avoid KeyError: 'PublicPort'

### DIFF
--- a/docker_challenges/__init__.py
+++ b/docker_challenges/__init__.py
@@ -276,7 +276,8 @@ def get_unavailable_ports(docker):
     for i in r.json():
         if not i['Ports'] == []:
             for p in i['Ports']:
-                result.append(p['PublicPort'])
+                if 'PublicPort'in p:
+                    result.append(p['PublicPort'])
     return result
 
 


### PR DESCRIPTION
I was running CTFd in a docker host that had portainer.io running at the same time. And I got an error message containing KeyError: 'PublicPort'. 

Once I looked into https://my-https-docker:2376/containers/json?all=1 I could see why the error happened.

The portainer ports looks like this: 

"Ports":[
   {
      "IP":"0.0.0.0",
      "PrivatePort":9443,
      "PublicPort":9443,
      "Type":"tcp"
   },
   {
      "IP":"0.0.0.0",
      "PrivatePort":8000,
      "PublicPort":5080,
      "Type":"tcp"
   },
   {
      "PrivatePort":9000,
      "Type":"tcp"
}.

Adding an extra check to verify that the Ports contain the key PublicPort