### PR TITLE
Convert from str to bytes before writing https related files.

### DIFF
--- a/docker_challenges/__init__.py
+++ b/docker_challenges/__init__.py
@@ -238,13 +238,13 @@ def get_client_cert(docker):
         client = docker.client_cert
         ckey = docker.client_key
         ca_file = tempfile.NamedTemporaryFile(delete=False)
-        ca_file.write(ca)
+        ca_file.write(ca.encode())
         ca_file.seek(0)
         client_file = tempfile.NamedTemporaryFile(delete=False)
-        client_file.write(client)
+        client_file.write(client.encode())
         client_file.seek(0)
         key_file = tempfile.NamedTemporaryFile(delete=False)
-        key_file.write(ckey)
+        key_file.write(ckey.encode())
         key_file.seek(0)
         CERT = (client_file.name, key_file.name)
     except:
@@ -298,13 +298,13 @@ def create_container(docker, image, team, portbl):
             client = docker.client_cert
             ckey = docker.client_key
             ca_file = tempfile.NamedTemporaryFile(delete=False)
-            ca_file.write(ca)
+            ca_file.write(ca.encode())
             ca_file.seek(0)
             client_file = tempfile.NamedTemporaryFile(delete=False)
-            client_file.write(client)
+            client_file.write(client.encode())
             client_file.seek(0)
             key_file = tempfile.NamedTemporaryFile(delete=False)
-            key_file.write(ckey)
+            key_file.write(ckey.encode())
             key_file.seek(0)
             CERT = (client_file.name, key_file.name)
         except:


### PR DESCRIPTION
Hi, 

I was setting up CTFd with docker over HTTPS, and I found errors when trying to connect over https. 

The stack trace: 
ctfd-ctfd-1   | /usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py:981: InsecureRequestWarning: Unverified HTTPS request is being made to host 'my-docker-https'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
ctfd-ctfd-1   |   warnings.warn(
ctfd-ctfd-1   | /usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py:981: InsecureRequestWarning: Unverified HTTPS request is being made to host 'my-docker-https'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
ctfd-ctfd-1   |   warnings.warn(
ctfd-ctfd-1   | Traceback (most recent call last):
ctfd-ctfd-1   |   File "/opt/CTFd/CTFd/plugins/docker_challenges/__init__.py", line 302, in create_container
ctfd-ctfd-1   |     ca_file.write(ca)
ctfd-ctfd-1   |   File "/usr/local/lib/python3.9/tempfile.py", line 478, in func_wrapper
ctfd-ctfd-1   |     return func(*args, **kwargs)
ctfd-ctfd-1   | TypeError: a bytes-like object is required, not 'str'

To translate from str to bytes I am using the .encode(), I don't know if this is due a change on the Python API. I am running with python 3.9