### PR TITLE
Get ExposedPorts from Config if it does not exist in ContainerConfig

### DIFF
--- a/docker_challenges/__init__.py
+++ b/docker_challenges/__init__.py
@@ -282,8 +282,11 @@ def get_unavailable_ports(docker):
 
 def get_required_ports(docker, image):
     r = do_request(docker, f'/images/{image}/json?all=1')
-    result = r.json()['ContainerConfig']['ExposedPorts'].keys()
-    return result
+    result = r.json()
+    ports = (result['ContainerConfig']['ExposedPorts']\
+        if 'ExposedPorts' in result['ContainerConfig']\
+        else result['Config']['ExposedPorts']).keys()
+    return ports
 
 
 def create_container(docker, image, team, portbl):


### PR DESCRIPTION
In images builded using BuildKit, `ExposedPorts` does not exist in `Config` field, not in `ContainerConfig` ([Related issue in `docker/cli`](https://github.com/docker/cli/issues/2868)).

Sample output of `docker image inspect` command for an image built using BuildKit:

```
[
    {
        "Id": "sha256:2dfa6c380c5fa5a1e7e99e137032f314d3121c755a713cd3a60dc7454124ad50",
        "RepoTags": [
            "testi:latest"
        ],
        "RepoDigests": [],
        "Parent": "",
        "Comment": "buildkit.dockerfile.v0",
        "Created": "2023-03-23T20:57:30.366632471Z",
        "Container": "",
        "ContainerConfig": {
            "Hostname": "",
            "Domainname": "",
            "User": "",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": null,
            "Cmd": null,
            "Image": "",
            "Volumes": null,
            "WorkingDir": "",
            "Entrypoint": null,
            "OnBuild": null,
            "Labels": null
        },
        "DockerVersion": "",
        "Author": "",
        "Config": {
            "Hostname": "",
            "Domainname": "",
            "User": "",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "ExposedPorts": {
                "80/tcp": {}
            },
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": [
                ...
            ],
            "Cmd": null,
            "Image": "",
            "Volumes": null,
            "WorkingDir": "/var/www/html",
            "Entrypoint": [
                "/bin/bash",
                "/tmp/docker-entrypoint.sh"
            ],
            "OnBuild": null,
            "Labels": null,
            "StopSignal": "SIGWINCH"
        },
        "Architecture": "arm64",
        ...
    }
]
```

This PR fixes getting exposed ports from images built using BuildKit.