### PR TITLE
fix bug when starting multiple instances in team mode

### DIFF
--- a/docker_challenges/__init__.py
+++ b/docker_challenges/__init__.py
@@ -597,8 +597,12 @@ class ContainerAPI(Resource):
         # Check if a container is already running for this user. We need to recheck the DB first
         containers = DockerChallengeTracker.query.all()
         for i in containers:
-            if int(session.id) == int(i.user_id):
-                return abort(403,f"Another container is already running for challenge:<br><i><b>{i.challenge}</b></i>.<br>Please stop this first.<br>You can only run one container.")
+            if is_teams_mode():
+                if int(session.id) == int(i.team_id):
+                    return abort(403,f"Another container is already running for challenge:<br><i><b>{i.challenge}</b></i>.<br>Please stop this first.<br>You can only run one container.")
+            else:
+                if int(session.id) == int(i.user_id):
+                    return abort(403,f"Another container is already running for challenge:<br><i><b>{i.challenge}</b></i>.<br>Please stop this first.<br>You can only run one container.")
 
         portsbl = get_unavailable_ports(docker)
         create = create_container(docker, container, session.name, portsbl)


### PR DESCRIPTION
When checking if a container is already running for this user the service crashes in team mode when multiple containers are started by different teams.

Tested on 3.7.7